### PR TITLE
Update rogdrv.desktop

### DIFF
--- a/rogdrv.desktop
+++ b/rogdrv.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Name=ASUS ROG Mouse Driver
-Comment=ASUS ROG Mouse Driver
 Icon=rog
 Exec=rogdrv
 Terminal=false

--- a/rogdrv/gtk3.py
+++ b/rogdrv/gtk3.py
@@ -99,7 +99,6 @@ class EventHandler(object):
 [Desktop Entry]
 Name=ROGDRV
 GenericName=ASUS ROG userspace driver
-Comment=ASUS ROG userspace driver
 Exec=rogdrv
 Terminal=false
 Type=Application


### PR DESCRIPTION
Update file to match Desktop Entry specification 1.4.

 # desktop-file-validate rogdrv.desktop 
rogdrv.desktop: warning: value "ASUS ROG Mouse Driver" for key "Comment" in group "Desktop Entry" looks the same as that of key "Name"