### PR TITLE
Add support for ROG Strix Impact II Wireless & different number of DPI presets

### DIFF
--- a/rogdrv/__main__.py
+++ b/rogdrv/__main__.py
@@ -213,9 +213,9 @@ def rogdrv_config():
                 device.set_dpi(int(args[2]), preset=preset)
                 device.save()
 
-            dpi1, dpi2, rate, response, snapping = device.get_dpi_rate_response_snapping()
-            print('DPI Preset 1: {}'.format(dpi1))
-            print('DPI Preset 2: {}'.format(dpi2))
+            dpi, rate, response, snapping = device.get_dpi_rate_response_snapping()
+            for idx, d in enumerate(dpi, start=1):
+                print('DPI Preset {}: {}'.format(idx, d))
             return
 
         elif args[1] == 'rate':
@@ -228,7 +228,7 @@ def rogdrv_config():
                 device.set_rate(int(args[2]))
                 device.save()
 
-            dpi1, dpi2, rate, response, snapping = device.get_dpi_rate_response_snapping()
+            dpi, rate, response, snapping = device.get_dpi_rate_response_snapping()
             print('Polling rate: {} Hz'.format(rate))
             return
 
@@ -242,7 +242,7 @@ def rogdrv_config():
                 device.set_response(int(args[2]))
                 device.save()
 
-            dpi1, dpi2, rate, response, snapping = device.get_dpi_rate_response_snapping()
+            dpi, rate, response, snapping = device.get_dpi_rate_response_snapping()
             print('Button response: {} ms'.format(response))
             return
 
@@ -256,7 +256,7 @@ def rogdrv_config():
                 device.set_snapping(int(args[2]))
                 device.save()
 
-            dpi1, dpi2, rate, response, snapping = device.get_dpi_rate_response_snapping()
+            dpi, rate, response, snapping = device.get_dpi_rate_response_snapping()
             print('Snapping angle: type {}'.format(snapping))
             return
 

--- a/rogdrv/device.py
+++ b/rogdrv/device.py
@@ -674,6 +674,18 @@ class StrixImpact(Device):
     buttons = 6
     leds = 1
 
+class StrixImpactII(Device):
+    product_id = 0x1947
+    keyboard_interface = 2
+    control_interface = 0
+    profiles = 3
+    buttons = 8
+    dpis = 4
+    leds = 1
+
+class StrixImpactIIWireless(StrixImpactII):
+    product_id = 0x1949
+    wireless = True
 
 class StrixEvolve(Device):
     product_id = 0x185B

--- a/rogdrv/device.py
+++ b/rogdrv/device.py
@@ -681,7 +681,7 @@ class StrixImpactII(Device):
     profiles = 3
     buttons = 8
     dpis = 4
-    leds = 1
+    leds = 3
 
 class StrixImpactIIWireless(StrixImpactII):
     product_id = 0x1949


### PR DESCRIPTION
Since ROG Strix Impact II has 4 DPI presets, The current codes cannot handle this correctly. Causing error when getting or setting DPI, rate, response time, and snapping configurations.

I modified the code handling DPI related configurations, making it possible to support more than 2 DPI presets.