### PR TITLE
Add support for Gladius 2 Origin Pink edition

### DIFF
--- a/rog/device.py
+++ b/rog/device.py
@@ -627,6 +627,11 @@ class Gladius2Origin(Gladius2):
     """
     product_id = 0x1877
 
+class Gladius2OriginPink(Gladius2):
+    """
+    ROG Gladius II Origin PNK LTD (8 buttons) - wired version, 12k DPI.
+    """
+    product_id = 0x18CD
 
 class Pugio(Device):
     """


### PR DESCRIPTION
I'm not sure if it should inherit of the Gladius2Origin class instead, in case we find Origin specific quirks later, but as for now I basically kept it the same as the original Gladius 2 Origin.
I'll be testing it a bit more.