### PR TITLE
fix an error in install_udev

### DIFF
--- a/install_udev
+++ b/install_udev
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from rog.device import DeviceMeta
+from rog.device.base import DeviceMeta
 
 UDEV_RULES = '/etc/udev/rules.d/50-rogdrv.rules'
 


### PR DESCRIPTION
trying to import from rog.device, but DeviceMeta is located in rog.device.base