### PR TITLE
Fix uinput memory allocation

### DIFF
--- a/rog/device/base.py
+++ b/rog/device/base.py
@@ -17,6 +17,7 @@
 import json
 import struct
 
+from evdev import ecodes
 from .. import defs, hid, logger
 from ..bindings import Bindings, get_action_type
 from ..leds import LEDs

--- a/rog/event.py
+++ b/rog/event.py
@@ -1,5 +1,6 @@
-from evdev import uinput, ecodes
-
+from evdev import uinput, ecodes, _ecodes
+from inspect import getmembers
+from . import defs
 
 class DeviceEventHandler(object):
     """
@@ -7,7 +8,18 @@ class DeviceEventHandler(object):
     Converts mouse events to evdev/uinput events.
     """
     def __init__(self):
-        self._uinput = uinput.UInput()
+        # TODO: change codes[val] = val to something correct in Python...
+        codes = {}
+        for code, val in getmembers(_ecodes):
+            if code.startswith("KEY"):
+                if (val >= ecodes.ecodes['KEY_ESC'] and val <= ecodes.ecodes['KEY_MEDIA']) or val == ecodes.ecodes['KEY_FN']:
+                    codes[val] = val
+            elif code.startswith("BTN"):
+                if (val >= ecodes.ecodes['BTN_LEFT'] and val <= ecodes.ecodes['BTN_TASK']):
+                    codes[val] = val
+
+        event = {ecodes.EV_KEY: codes.keys()}
+        self._uinput = uinput.UInput(events=event)
         self._last_pressed = set()
 
     def handle_event(self, pressed: set):


### PR DESCRIPTION
This patch fixes error:
Failed to write 'change' to '/sys/devices/virtual/input/input24/uevent':
Cannot allocate memory

This error is observed on some systems after calling "udevadm trigger". It was
caused by registering too much keys in evdev UInput object. This made remapped
buttons unusable.
By default, UInput uses all keyboard and mouse keys, which results in -ENOMEM.
Change it to use only standard keyboard and mouse keys.