### PR TITLE
Fix cannot set Strix Impact II Wireless battery related configurations when connected with wire

### DIFF
--- a/rog/device/rog.py
+++ b/rog/device/rog.py
@@ -115,8 +115,12 @@ class StrixImpact(Device):
     profiles = 0
 
 
-class StrixImpactII(Device):
+class StrixImpactIIWirelessWired(Device):
+    """
+    Strix Impact II WIreless with wire connected
+    """
     product_id = 0x1947
+    wireless = True
     keyboard_interface = 2
     control_interface = 0
     profiles = 3
@@ -125,9 +129,11 @@ class StrixImpactII(Device):
     leds = 3
 
 
-class StrixImpactIIWireless(StrixImpactII):
+class StrixImpactIIWireless(StrixImpactIIWirelessWired):
+    """
+    Strix Impact II Wireless in wireless mode
+    """
     product_id = 0x1949
-    wireless = True
 
 
 class StrixEvolve(Device):


### PR DESCRIPTION
This commit fix the issue that the Strix Impact II Wireless cannot get/set battery related configurations when connect with wire, by also setting the wireless attribute on wired device class.

Since there is non-wireless variant called "Strix Impact II", the wired class name is also renamed to `StrixImpactIIWirelessWired` to prevent confusion in the future.