### PR TITLE
Remove 'sudo' from install_udev script

### DIFF
--- a/install_udev
+++ b/install_udev
@@ -2,5 +2,5 @@
 
 UDEV_RULES=/etc/udev/rules.d/50-rogdrv.rules
 cp -fv udev/50-rogdrv.rules ${UDEV_RULES}
-sudo udevadm control --reload-rules
-sudo udevadm trigger
+udevadm control --reload-rules
+udevadm trigger


### PR DESCRIPTION
Having the command `sudo` included in the script
breaks compatibility with other privilege escalation programs, such as doas.
The README suggests to run the script with escalated privileges anyway, so having the command inside the script is redundant.